### PR TITLE
Fix weak conversion of X Axis to Column

### DIFF
--- a/reamber/osu/OsuNoteMeta.py
+++ b/reamber/osu/OsuNoteMeta.py
@@ -24,31 +24,24 @@ class OsuNoteMeta:
         self.hitsound_file: str = ""
 
     @staticmethod
-    def x_axis_to_column(x_axis: float, keys: int, clip: bool = True) -> int:
+    def x_axis_to_column(x_axis: float, keys: int) -> int:
         """Converts the x_axis code in .osu to an actual column value
-
-        Note that column starts from 0
 
         Args:
             x_axis: The code in .osu to convert
             keys: Required for conversion
-            clip: If true the return will be clipped to max of (keys - 1)
 
         Returns:
             The actual column value, starting from 0
         """
-        assert keys > 0, f"Keys cannot be negative. {keys}"
-        col = int(ceil((x_axis * keys - 256.0) / 512.0))
-        return min(keys - 1, col) if clip else col
+        return max(min(int(x_axis // (512 / keys)), keys - 1), 0)
 
     @staticmethod
     def column_to_x_axis(column: float, keys: int) -> int:
         """Converts the actual column value to a .osu writable code value
 
-        Note that column starts from 0
-
         Args:
-            column: The column to convert
+            column: The column to convert starting from 0
             keys: Required for conversion
 
         Returns:

--- a/rsc/maps/osu/Stella.osu
+++ b/rsc/maps/osu/Stella.osu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0355ea505811004ef69363589c4e1938a7b55f6a3014867311c0a874aac9d93b
+size 146950

--- a/tests/unit_tests/osu/out.osu
+++ b/tests/unit_tests/osu/out.osu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1ca1ef4a51305ab7e151c44b5b20e85eb97aa7716b7f12749112381dc5c92d8
-size 32839

--- a/tests/unit_tests/osu/test_x_axis_column_conv.py
+++ b/tests/unit_tests/osu/test_x_axis_column_conv.py
@@ -1,0 +1,31 @@
+import pytest
+
+from reamber.osu.OsuNoteMeta import OsuNoteMeta
+
+
+@pytest.mark.parametrize(
+    "x_axis, keys, expected",
+    [
+        (-1, 4, 0), (0, 4, 0), (1, 4, 0), (127, 4, 0),
+        (128, 4, 1), (129, 4, 1), (255, 4, 1),
+        (256, 4, 2), (257, 4, 2), (383, 4, 2),
+        (384, 4, 3), (385, 4, 3), (511, 4, 3), (512, 4, 3), (513, 4, 3)]
+)
+def test_x_axis_to_column_4k(x_axis, keys, expected):
+    assert OsuNoteMeta.x_axis_to_column(x_axis, keys) == expected
+
+
+@pytest.mark.parametrize(
+    "x_axis, keys, expected",
+    [
+        (-1, 7, 0), (0, 7, 0), (1, 7, 0), (72, 7, 0), (73, 7, 0),
+        (74, 7, 1), (145, 7, 1), (146, 7, 1),
+        (147, 7, 2), (218, 7, 2), (219, 7, 2),
+        (220, 7, 3), (291, 7, 3), (292, 7, 3),
+        (293, 7, 4), (364, 7, 4), (365, 7, 4),
+        (366, 7, 5), (437, 7, 5), (438, 7, 5),
+        (439, 7, 6), (511, 7, 6), (512, 7, 6), (513, 7, 6)
+    ]
+)
+def test_x_axis_to_column_7k(x_axis, keys, expected):
+    assert OsuNoteMeta.x_axis_to_column(x_axis, keys) == expected


### PR DESCRIPTION
Described in #75 

The issue was that if a value is 1 off, it'll break the parsing with `OsuNoteMeta.x_axis_to_column(x_axis, keys)`.

This solves this by making the conversion mimic how osu! handles these odd values.


Closes #75