### PR TITLE
Use float for osu! slider tick rate

### DIFF
--- a/reamber/osu/OsuMapMeta.py
+++ b/reamber/osu/OsuMapMeta.py
@@ -154,7 +154,7 @@ class OsuMapMeta(OsuMapMetaGeneral,
             elif k == "SliderMultiplier":
                 self.slider_multiplier = float(v)
             elif k == "SliderTickRate":
-                self.slider_tick_rate = int(v)
+                self.slider_tick_rate = float(v)
 
             if k == "//Background and Video events":
                 line = lines[e + 1]


### PR DESCRIPTION
Values like 0.5 can be used which makes parsing fail

Refer to https://github.com/ppy/osu-wiki/blob/master/meta/unused/difficulty-settings.md

Probably need to fix docs but unsure what to change so feel free to add additional commits