### PR TITLE
Add categorization of replay error note type

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov for 3.9
       if: ${{ matrix.python-version == '3.9' }}
-      uses: codecov/codecov-action@v3.1.3
+      uses: codecov/codecov-action@v3.1.4
       with:
         files: ${{ matrix.test-type }}.xml
         verbose: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov for 3.9
       if: ${{ matrix.python-version == '3.9' }}
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v3
       with:
         files: ${{ matrix.test-type }}.xml
         verbose: true

--- a/reamber/algorithms/osu/parse_replay.py
+++ b/reamber/algorithms/osu/parse_replay.py
@@ -214,7 +214,7 @@ def parse_replays_error(
                 'replay_id': df_id,
                 'offset': np.concatenate([ar_map_hit, ar_map_rel]).astype(int),
                 'column': np.concatenate([ar_map_hit_col, ar_map_hold_col, ar_map_hold_col]),
-                'category': pd.Series([*("Hit",) * n_hits, *("Hold Head",) *  n_holds , *("Hold Tail", ) * n_holds],
+                'category': pd.Series([*("Hit",) * n_hits, *("Hold Head",) * n_holds, *("Hold Tail",) * n_holds],
                                       dtype='category'),
                 'error': np.concatenate([ar_map_hit_error, ar_map_rel_error]).astype(int),
             },

--- a/reamber/algorithms/osu/parse_replay.py
+++ b/reamber/algorithms/osu/parse_replay.py
@@ -163,6 +163,7 @@ def parse_replays_error(
 
     Args:
         replays: A dictionary of key: id, value: replays paths OR response contents from v1 get_replay/ API.
+        osu: Map to reference errors from
         src: Must be "api", "file", indicating the source of the data or "infer" to automatically infer the source
 
     Returns:

--- a/reamber/algorithms/osu/parse_replay.py
+++ b/reamber/algorithms/osu/parse_replay.py
@@ -190,6 +190,9 @@ def parse_replays_error(
     # Retrieve offsets where map should be released
     ar_map_rel = osu.holds.tail_offset.to_numpy()
 
+    n_hits = len(osu.hits)
+    n_holds = len(osu.holds)
+
     dfs_error = []
     for df_action, df_id in tqdm(zip(dfs_action, replays.keys()),
                                  desc="Parsing Replay Errors", total=len(dfs_action)):
@@ -210,8 +213,8 @@ def parse_replays_error(
                 'replay_id': df_id,
                 'offset': np.concatenate([ar_map_hit, ar_map_rel]).astype(int),
                 'column': np.concatenate([ar_map_hit_col, ar_map_hold_col, ar_map_hold_col]),
-                'is_press': np.concatenate([np.ones_like(ar_map_hit_error),
-                                            np.zeros_like(ar_map_rel_error)]).astype(bool),
+                'category': pd.Series([*("Hit",) * n_hits, *("Hold Head",) *  n_holds , *("Hold Tail", ) * n_holds],
+                                      dtype='category'),
                 'error': np.concatenate([ar_map_hit_error, ar_map_rel_error]).astype(int),
             },
         ).set_index('replay_id', append=True))

--- a/tests/algorithm_tests/osu/replay/test_parse_replay.py
+++ b/tests/algorithm_tests/osu/replay/test_parse_replay.py
@@ -9,16 +9,14 @@ from tests.conftest import MAPS_DIR, REPS_OSU_DIR
 
 MAP_PATH = MAPS_DIR / "osu/MAGiCVLGiRL_ZVPH.osu"
 REPS_PATH = list((REPS_OSU_DIR / "MAGiCVLGiRL_ZVPH.osu/").glob("*.osr"))[:2]
+N_REPS = len(REPS_PATH)
 PKL_PATH = Path(__file__).parent / "errors.pkl"
 osu = OsuMap.read_file(MAP_PATH.as_posix())
 
 
 def test_parse_replay_action_osr():
-    df_actions = parse_replay_actions(
-        replay=REPS_PATH[0],
-        keys=4,
-        src='file'
-    )
+    print(REPS_PATH)
+    df_actions = parse_replay_actions(replay=REPS_PATH[0], keys=4, src='file')
     assert isinstance(df_actions, pd.DataFrame)
 
 
@@ -27,7 +25,10 @@ def test_parse_replays_error_osr():
         {r.as_posix(): r.as_posix() for r in REPS_PATH},
         osu=osu, src="file"
     )
-    assert isinstance(df_errors, pd.DataFrame)
+    cat_counts = df_errors.category.value_counts()
+    assert cat_counts['Hit'] == len(osu.hits) * N_REPS
+    assert cat_counts['Hold Head'] == len(osu.holds) * N_REPS
+    assert cat_counts['Hold Tail'] == len(osu.holds) * N_REPS
 
 
 def test_parse_replays_error_osr_infer():
@@ -35,7 +36,10 @@ def test_parse_replays_error_osr_infer():
         {r.as_posix(): r.as_posix() for r in REPS_PATH},
         osu=osu, src="infer"
     )
-    assert isinstance(df_errors, pd.DataFrame)
+    cat_counts = df_errors.category.value_counts()
+    assert cat_counts['Hit'] == len(osu.hits) * N_REPS
+    assert cat_counts['Hold Head'] == len(osu.holds) * N_REPS
+    assert cat_counts['Hold Tail'] == len(osu.holds) * N_REPS
 
 
 def test_parse_replays_error_api():
@@ -43,7 +47,10 @@ def test_parse_replays_error_api():
         data = json.load(f)
 
     df_errors = parse_replays_error({'rep1': data['content']}, osu=osu, src='api')
-    assert isinstance(df_errors, pd.DataFrame)
+    cat_counts = df_errors.category.value_counts()
+    assert cat_counts['Hit'] == len(osu.hits)
+    assert cat_counts['Hold Head'] == len(osu.holds)
+    assert cat_counts['Hold Tail'] == len(osu.holds)
 
 
 def test_parse_replays_error_api_infer():
@@ -51,4 +58,7 @@ def test_parse_replays_error_api_infer():
         data = json.load(f)
 
     df_errors = parse_replays_error({'rep1': data['content']}, osu=osu, src='infer')
-    assert isinstance(df_errors, pd.DataFrame)
+    cat_counts = df_errors.category.value_counts()
+    assert cat_counts['Hit'] == len(osu.hits)
+    assert cat_counts['Hold Head'] == len(osu.holds)
+    assert cat_counts['Hold Tail'] == len(osu.holds)


### PR DESCRIPTION
# Major Changes
- Replaced `error_type` with `category`
- Improve `test_parse_replay` robustness