### PR TITLE
Hotfix parse replay tqdm spam and expose option to turn off tqdm

### DIFF
--- a/tests/algorithm_tests/osu/replay/test_parse_replay.py
+++ b/tests/algorithm_tests/osu/replay/test_parse_replay.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from reamber.algorithms.osu.parse_replay import parse_replays_error, parse_replay_actions
 from reamber.osu import OsuMap
@@ -19,45 +20,32 @@ def test_parse_replay_action_osr():
     assert isinstance(df_actions, pd.DataFrame)
 
 
-def test_parse_replays_error_osr():
-    df_errors = parse_replays_error(
-        {r.as_posix(): r.as_posix() for r in REPS_PATH},
-        osu=osu, src="file"
-    )
+@pytest.mark.parametrize(
+    'src',
+    ('file', 'infer')
+)
+def test_parse_replays_error_osr(src: str):
+    df_errors = parse_replays_error({r.as_posix(): r.as_posix() for r in REPS_PATH}, osu=osu, src=src)
     cat_counts = df_errors.category.value_counts()
     assert cat_counts['Hit'] == len(osu.hits) * N_REPS
     assert cat_counts['Hold Head'] == len(osu.holds) * N_REPS
     assert cat_counts['Hold Tail'] == len(osu.holds) * N_REPS
 
-
-def test_parse_replays_error_osr_infer():
-    df_errors = parse_replays_error(
-        {r.as_posix(): r.as_posix() for r in REPS_PATH},
-        osu=osu, src="infer"
-    )
-    cat_counts = df_errors.category.value_counts()
-    assert cat_counts['Hit'] == len(osu.hits) * N_REPS
-    assert cat_counts['Hold Head'] == len(osu.holds) * N_REPS
-    assert cat_counts['Hold Tail'] == len(osu.holds) * N_REPS
+    # There shouldn't be any misses within the replay, there are still some errors in the parsing due to estimation.
+    assert df_errors.loc[df_errors.error.abs() > 100].empty
 
 
-def test_parse_replays_error_api():
+@pytest.mark.parametrize(
+    'src',
+    ('api', 'infer')
+)
+def test_parse_replays_error_api(src: str):
     with open(Path(__file__).parent / "response.json", "r") as f:
         data = json.load(f)
 
-    df_errors = parse_replays_error({'rep1': data['content']}, osu=osu, src='api')
+    df_errors = parse_replays_error({'rep1': data['content']}, osu=osu, src=src)
     cat_counts = df_errors.category.value_counts()
     assert cat_counts['Hit'] == len(osu.hits)
     assert cat_counts['Hold Head'] == len(osu.holds)
     assert cat_counts['Hold Tail'] == len(osu.holds)
 
-
-def test_parse_replays_error_api_infer():
-    with open(Path(__file__).parent / "response.json", "r") as f:
-        data = json.load(f)
-
-    df_errors = parse_replays_error({'rep1': data['content']}, osu=osu, src='infer')
-    cat_counts = df_errors.category.value_counts()
-    assert cat_counts['Hit'] == len(osu.hits)
-    assert cat_counts['Hold Head'] == len(osu.holds)
-    assert cat_counts['Hold Tail'] == len(osu.holds)


### PR DESCRIPTION
# Major Change
- Fix issue with tqdm spam for each column in keys
- Expose `verbose` as argument for `disable` in `tqdm`